### PR TITLE
User table changes

### DIFF
--- a/classes/bpModBackend.php
+++ b/classes/bpModBackend.php
@@ -27,6 +27,12 @@ class bpModBackend extends bpModeration
 		add_action('rightnow_end', array(&$this, 'rightnow_widget_section'));
 		add_action('admin_init', array(&$this, 'register_settings'));
 
+		// Add a "Spammers" view to the WP Users List Table
+		add_filter( 'views_users', array( $this, 'add_spammers_filter_link' ) );
+		// Apply the filter when necessary.
+		add_filter( 'pre_get_users', array( $this, 'apply_spammers_filter' ) );
+
+
 		if (isset($this->options['generate_test_data'])) {
 			unset($this->options['generate_test_data']);
 			update_site_option('bp_moderation_options', $this->options);
@@ -1460,6 +1466,70 @@ SQL;
 		}
 
 		echo $input;
+	}
+
+	/**
+	 * Add a "spammers" list view to the WP Users List Table.
+	 *
+	 * @since  0.2.0
+	 *
+	 * @param array $views An array of available list table views.
+	 *
+	 * @return array $views
+	 */
+	public function add_spammers_filter_link( $views ) {
+		global $wpdb;
+
+		if ( is_network_admin() ) {
+			$base_url = network_admin_url( 'users.php' );
+			$count = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->users WHERE ($wpdb->users.user_status = 1 OR $wpdb->users.spam = 1)" );
+		} else {
+			$base_url = bp_get_admin_url( 'users.php' );
+			$count = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->users WHERE $wpdb->users.user_status = 1" );
+		}
+
+		$url = add_query_arg( 'type', 'spam', $base_url );
+
+		if ( isset( $_GET[ 'type' ] ) && 'spam' == $_GET[ 'type' ] ) {
+			$views['all'] = str_replace( 'class="current"', '', $views['all'] );
+			$active_class = 'current';
+		} else {
+			$active_class = '';
+		}
+
+		$views['spam'] = sprintf( '<a href="%s" class="%s">%s <span class="count">(%d)</span></a>', $url, $active_class, __( 'Spam', 'bp-moderate' ), number_format_i18n( $count ) );
+
+		return $views;
+	}
+
+	/**
+	 * Filter the user query to "spammers" on the WP Users List Table.
+	 *
+	 * @since  0.2.0
+	 *
+	 * @param WP_User_Query $query The current WP_User_Query instance,
+	 *                             passed by reference.
+	 */
+	function apply_spammers_filter( $query ) {
+		global $pagenow, $wpdb;
+
+		if ( is_admin() && 'users.php' == $pagenow && isset( $_GET[ 'type' ] ) && 'spam' == $_GET[ 'type' ] ) {
+
+			// I'm not seeing a way to make WP_User_Query use the user_status column, so...
+			$user_ids = array();
+			if ( is_network_admin() ) {
+				$user_ids = $wpdb->get_col( "SELECT ID FROM $wpdb->users WHERE ($wpdb->users.user_status = 1 OR $wpdb->users.spam = 1)" );
+			} else {
+				$user_ids = $wpdb->get_col( "SELECT ID FROM $wpdb->users WHERE $wpdb->users.user_status = 1" );
+			}
+
+			// Passing an empty array to the 'include' parameter returns all users. Don't do that.
+			if ( empty( $user_ids ) ) {
+				$user_ids = array( 0 );
+			}
+
+			$query->set( 'include', $user_ids );
+		}
 	}
 }
 

--- a/classes/bpModBackend.php
+++ b/classes/bpModBackend.php
@@ -27,6 +27,15 @@ class bpModBackend extends bpModeration
 		add_action('rightnow_end', array(&$this, 'rightnow_widget_section'));
 		add_action('admin_init', array(&$this, 'register_settings'));
 
+		// Add a "date_registered" column to the WP Users list table.
+		// Useful for moderating recently registered users.
+		add_filter( 'manage_users_columns', array( $this, 'add_date_registered_column') );
+		// Populate our new column in the WP Users list table.
+		add_action( 'manage_users_custom_column', array( $this, 'date_registered_column_content' ), 10, 3);
+		// Tell WP that our new column is sortable.
+		add_filter( 'manage_users_sortable_columns', array( $this, 'date_registered_column_declare_sortable' ) );
+		// Sorting will work as expected because the column name is the orderby keyword, "user_registered".
+
 		// Add a "Spammers" view to the WP Users List Table
 		add_filter( 'views_users', array( $this, 'add_spammers_filter_link' ) );
 		// Apply the filter when necessary.
@@ -1466,6 +1475,53 @@ SQL;
 		}
 
 		echo $input;
+	}
+
+	/**
+	 * Add our new column to the WP Users list table.
+	 *
+	 * @since  0.2.0
+	 *
+	 * @param  array $columns The array of columns to include.
+	 *
+	 * @return array $columns
+	 */
+	public function add_date_registered_column( $columns ) {
+		$columns['user_registered'] = __( 'Date Registered', 'bp-moderation' );
+		return $columns;
+	}
+
+	/**
+	 * Populate our new column in the WP Users list table.
+	 *
+	 * @since  0.2.0
+	 *
+	 * @param  string $value       Custom column output. Default empty.
+	 * @param  string $column_name Column name.
+	 * @param  int $user_id        ID of the currently-listed user.
+	 *
+	 * @return array $columns
+	 */
+	public function date_registered_column_content( $value, $column_name, $user_id ) {
+		if ( 'user_registered' == $column_name ) {
+			$user = get_userdata( $user_id );
+			return $user->user_registered;
+		}
+		return $value;
+	}
+
+	/**
+	 * Tell WP that our new column is sortable.
+	 *
+	 * @since  0.2.0
+	 *
+	 * @param  array $columns The array of columns to make sortable.
+	 *
+	 * @return array $columns
+	 */
+	public function date_registered_column_declare_sortable( $columns ) {
+		$columns['user_registered'] = 'user_registered';
+		return $columns;
 	}
 
 	/**

--- a/classes/bpModDefaultContentTypes.php
+++ b/classes/bpModDefaultContentTypes.php
@@ -156,8 +156,8 @@ class bpModDefaultContentTypes
 			add_filter('bp_moderation_activity_loop_link_args_new_forum_topic', array(__CLASS__, 'forum_post_convert_activity_args'));
 			add_action('bp_group_forum_post_meta', array(__CLASS__, 'forum_post_print_link'));
 		}
-	
-                
+
+
 		//  private message sender
 		$bpmod->content_types['private_message_sender'] = new stdClass();
 		$bpmod->content_types['private_message_sender']->label = __('Private message sender', 'bp-moderation');
@@ -169,7 +169,7 @@ class bpModDefaultContentTypes
 		if (isset ($init_types['private_message_sender'])) {
 			add_action('bp_after_message_thread_list', array(__CLASS__, 'private_message_sender_print_links'));
 		}
-		
+
 		//  private message
 		$bpmod->content_types['private_message'] = new stdClass();
 		$bpmod->content_types['private_message']->label = __('Private message', 'bp-moderation');
@@ -651,7 +651,7 @@ class bpModDefaultContentTypes
 
 		echo "<span class='links-separator'> | </span>$link";
 	}
-	
+
 
 /*******************************************************************************
  * Private message sender
@@ -670,17 +670,17 @@ class bpModDefaultContentTypes
 									));
 			}
 		}
-		
+
 		if (!count($report_links)) {
 			return;
 		}
-		
+
 		echo '<p class="bp-mod-pm-thread-links">';
 		printf(__('Flag sender as inappropriate: %s', 'bp-moderation'),join(' ', $report_links));
 		echo '</p>';
 	}
 
-	
+
 /*******************************************************************************
  * Private message
  */
@@ -691,13 +691,13 @@ class bpModDefaultContentTypes
 			return false;
 		}
 		$url = bp_core_get_user_domain($sender_id) . bp_get_messages_slug() . '/view/' . $thread_id;
-		
+
 		foreach ((array) $thread->messages as $msg) {
 			if ($sender_id == $msg->sender_id) {
 				return array('author' => $sender_id, 'url' => $url, 'date' => $msg->date_sent);
 			}
 		}
-		
+
 		return false;
 	}
 
@@ -734,19 +734,19 @@ class bpModDefaultContentTypes
 										'id' => bp_get_the_thread_id(),
 										'id2' => $sender_id,
 										'unflagged_text' => __('Flag message', 'bp-moderation'),
-										'custom_class' => 'button'
+										'custom_class' => 'alignright button'
 									));
 
 		echo '<p class="bp-mod-pm-thread-links">';
 		echo $report_link;
 		echo '</p>';
 	}
-	
+
 	public static function private_message_view_link_override($content) {
 		$content->item_url = wp_nonce_url($content->item_url.'?bpmSuperAdminOverridePrivateMessage', 'bpmSuperAdminOverridePrivateMessage');
 		return $content;
 	}
-	
+
 	public static function private_message_super_admin_override() {
 		if(!isset($_GET['bpmSuperAdminOverridePrivateMessage']) || !is_super_admin()) {
 			return;


### PR DESCRIPTION
Here are a couple of changes to the WP Users List Table that make it easier to sort for recently registered members and also to see the users that you've marked as spam via the BP Moderation screens (so you can delete them easily).

Thanks!